### PR TITLE
Fix category route

### DIFF
--- a/dreamcollections-microservices/api-gateway-service/src/main/resources/application.properties
+++ b/dreamcollections-microservices/api-gateway-service/src/main/resources/application.properties
@@ -28,7 +28,7 @@ spring.cloud.gateway.routes[2].filters[0]=StripPrefix=1
 # 3: Categories ? product-catalog-service
 spring.cloud.gateway.routes[3].id=product-catalog-service-categories
 spring.cloud.gateway.routes[3].uri=http://product-catalog-service:8082
-spring.cloud.gateway.routes[3].predicates[0]=Path=/api/categories/**
+spring.cloud.gateway.routes[3].predicates[0]=Path=/api/categories,/api/categories/**
 spring.cloud.gateway.routes[3].filters[0]=StripPrefix=1
 
 # 4: Carts ? cart-service (port 8083)


### PR DESCRIPTION
## Summary
- fix API gateway category route path so `/api/categories` resolves correctly

## Testing
- `mvnw -q test` *(fails: network access blocked)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d33bf739c8323b4332477e733afaa