### PR TITLE
Fix CORS setup in product catalog service

### DIFF
--- a/dreamcollections-microservices/product-catalog-service/src/main/java/com/dreamcollections/services/product/config/SecurityConfig.java
+++ b/dreamcollections-microservices/product-catalog-service/src/main/java/com/dreamcollections/services/product/config/SecurityConfig.java
@@ -56,7 +56,6 @@ public class SecurityConfig {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .csrf(csrf -> csrf.disable())
-            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .exceptionHandling(exception -> exception.authenticationEntryPoint(unauthorizedHandler))
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth


### PR DESCRIPTION
## Summary
- remove duplicate CORS configuration from `SecurityConfig`

## Testing
- `./mvnw -q test` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_686d3838bb388323a7a1bc3f0662980e