### PR TITLE
Fix CORS origin port

### DIFF
--- a/dreamcollections-microservices/api-gateway-service/src/main/resources/application.properties
+++ b/dreamcollections-microservices/api-gateway-service/src/main/resources/application.properties
@@ -44,9 +44,9 @@ spring.cloud.gateway.routes[5].predicates[0]=Path=/api/orders/**
 spring.cloud.gateway.routes[5].filters[0]=StripPrefix=1
 
 # ----------------------------------------------------------------
-# Global CORS (so your browser at localhost:5174 can talk to the gateway)
+# Global CORS (so your browser at localhost:5173 can talk to the gateway)
 # ----------------------------------------------------------------
-spring.cloud.gateway.globalcors.corsConfigurations.[/**].allowedOrigins=http://localhost:5174
+spring.cloud.gateway.globalcors.corsConfigurations.[/**].allowedOrigins=http://localhost:5173
 spring.cloud.gateway.globalcors.corsConfigurations.[/**].allowedMethods=GET,POST,PUT,DELETE,OPTIONS
 spring.cloud.gateway.globalcors.corsConfigurations.[/**].allowedHeaders=*
 spring.cloud.gateway.globalcors.corsConfigurations.[/**].allowCredentials=true

--- a/dreamcollections-microservices/product-catalog-service/src/main/java/com/dreamcollections/services/product/config/SecurityConfig.java
+++ b/dreamcollections-microservices/product-catalog-service/src/main/java/com/dreamcollections/services/product/config/SecurityConfig.java
@@ -93,7 +93,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:5174"));
+        config.setAllowedOrigins(List.of("http://localhost:5173"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);


### PR DESCRIPTION
## Summary
- allow gateway CORS from localhost:5173
- match product catalog service CORS origin to Vite dev server

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_686d389fa29c8323a530eb0fff96e7fe